### PR TITLE
bnc#872029 auditlog-keeper: shutdown and start fail when using parameter restart

### DIFF
--- a/core/scripts/auditlog-keeper
+++ b/core/scripts/auditlog-keeper
@@ -77,12 +77,19 @@ case "$1" in
         # Make sure the process actually disappeared
         checkproc $AK_BIN
         STOPPED=$?
+        TRIES="0"
         if [ $STOPPED -eq 0 ]; then
             while [ $STOPPED -eq 0 ]
             do
                sleep 1
                checkproc $AK_BIN
                STOPPED=$?
+               TRIES=$[$TRIES + 1]
+               if [ $TRIES -gt 5 ]; then
+                   rc_failed 1
+                   rc_status -v
+                   exit 1
+               fi
             done
         fi
 


### PR DESCRIPTION
The command `rcauditlog-keeper start` and `rcauditlog-keeper stop` alone works fine. The problem arises with `rcauditlog-keeper restart`, which is just batch-call of `stop` and `start` one after another, because the process needs about half a second to properly quit and therefore `checkproc` will not detect it anymore.

Additionally, I've added a timeout of 5 seconds, so if in any case process cannot quit (should not happen and never happened during the tests, but who knows?..) then the `stop` command will quit anyway with a failure message.

@dmacvicar Please take a look.
