### PR TITLE
rename jar to commons-logging.jar

### DIFF
--- a/core/scripts/sm-audit.sh
+++ b/core/scripts/sm-audit.sh
@@ -9,7 +9,7 @@ CP=$CLASSPATH
 CONFIG="/etc/auditlog-keeper.conf"
 
 LIBS="
-jakarta-commons-logging.jar
+commons-logging.jar
 tiny-sqlmap.jar
 apache-xmlrpc3-client.jar
 apache-xmlrpc3-server.jar


### PR DESCRIPTION
rename the jar from jakarta-commons-logging.jar to commons-logging.jar

commons-logging.jar is provided by jakarta as well as apache